### PR TITLE
IBM: Using GPUs to Scale and Speed-up Deep Learning

### DIFF
--- a/courses.json
+++ b/courses.json
@@ -464,6 +464,16 @@
       "module_number" : 8,
       "certification" : "paid"
     }
+    {
+      "id" :  49,
+      "platform" : "edX",
+      "free_course" : "yes",
+      "course_name" : " IBM: Using GPUs to Scale and Speed-up Deep Learning"
+      "link" : "https://www.edx.org/learn/data-analysis/ibm-using-gpus-to-scale-and-speed-up-deep-learning",
+      "difficulty" : "beginner",
+      "module_number" : 8,
+      "certification" : "paid"
+    }
     
     
     


### PR DESCRIPTION
Training complex deep learning models with large datasets takes along time. In this course, you will learn how to use accelerated GPU hardware to overcome the scalability problem in deep learning